### PR TITLE
'boost::http_config' for 'install_plain_http_server'

### DIFF
--- a/example/server/main.cpp
+++ b/example/server/main.cpp
@@ -61,11 +61,11 @@ int server_main( int argc, char* argv[] )
 
         install_services(app);
 
+        http_config config = http_config::make_config(argv);
+        
         auto& srv = install_plain_http_server(
             app,
-            argv[1],
-            (unsigned short)std::atoi(argv[2]),
-            std::atoi(argv[4]));
+            config);
 
         //srv.wwwroot.use("/log", serve_log_admin(app));
         //srv.wwwroot.use("/alt", serve_static( argv[3] ));

--- a/include/boost/beast2/server/http_server.hpp
+++ b/include/boost/beast2/server/http_server.hpp
@@ -15,6 +15,8 @@
 #include <boost/capy/application.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
+#include <string>
+
 namespace boost {
 namespace beast2 {
 
@@ -40,13 +42,39 @@ public:
 
 //------------------------------------------------
 
+/**
+    @brief HTTP Configuration structure for 'install_plain_http_server'.
+*/
+struct http_config final {
+    ~http_config() = default;
+
+    http_config() = default;
+
+    std::size_t http_num_workers_{0UL};
+    std::string http_addr_{};
+    std::uint16_t http_port_{0U};
+
+    static http_config make_config(const char** argv)
+    {
+        http_config config{};
+     
+        if (!argv || *argv == nullptr) return config;
+     
+        config.http_num_workers_ = (unsigned short)std::atoi(argv[2]);
+        config.http_addr_ = argv[1];
+        config.http_port_ = std::atoi(argv[4]);
+
+        return config;
+    }
+};
+
+//------------------------------------------------
+
 BOOST_BEAST2_DECL
 auto
 install_plain_http_server(
     capy::application& app,
-    char const* addr,
-    unsigned short port,
-    std::size_t num_workers) ->
+    http_config& config) ->
         http_server<asio::basic_stream_socket<
             asio::ip::tcp,
             asio::io_context::executor_type>>&;

--- a/src/server/http_server.cpp
+++ b/src/server/http_server.cpp
@@ -12,9 +12,13 @@
 #include <boost/beast2/server/plain_worker.hpp>
 #include <boost/beast2/asio_io_context.hpp>
 #include <boost/capy/application.hpp>
+#include <boost/assert.hpp>
 
 namespace boost {
 namespace beast2 {
+namespace detail {
+    constexpr const std::size_t worker_thread_min = 1UL;
+}
 
 namespace {
 
@@ -75,18 +79,31 @@ private:
 auto
 install_plain_http_server(
     capy::application& app,
-    char const* addr,
-    unsigned short port,
-    std::size_t num_workers) ->
+    http_config& config) ->
         http_server<asio::basic_stream_socket<
             asio::ip::tcp,
             asio::io_context::executor_type>>&
 {
     using stream_type = asio::basic_stream_socket<
         asio::ip::tcp, asio::io_context::executor_type>;
+
+    /// AMLALE: Default value of workers is 1.
+    std::size_t num_workers = detail::worker_thread_min;
+
+    auto nworkers = config.http_num_workers_;
+    
+    if (nworkers > detail::worker_thread_min)
+        num_workers = nworkers;
+
     auto& srv = app.emplace<http_server_impl<stream_type>>(
         app, num_workers);
-    srv.add_port(addr, port);
+
+    auto ps_addr = config.http_addr_;
+    auto ps_port = config.http_port_;
+
+    BOOST_ASSERT(!ps_addr.empty() && (ps_port > 0));
+    srv.add_port(ps_addr.c_str(), ps_port);
+    
     return srv;
 }
 


### PR DESCRIPTION
## Rationale:

Parses a `boost::http_config` to start an `http_server_impl` type.

## Example:

```cpp
    boost::http_config config = boost::http_config::make_config(argv);


    auto& srv = boost::install_plain_http_server(
        app,
        config);
```

Amlal.