### PR TITLE
chore: fix MinGW builds

### DIFF
--- a/src/server/basic_router.cpp
+++ b/src/server/basic_router.cpp
@@ -80,8 +80,7 @@ pattern     target      path(use)    path(get)
 
 //------------------------------------------------
 
-
-any_router::any_handler::~any_handler() = default;
+any_router::any_handler::~any_handler() {}
 
 //------------------------------------------------
 


### PR DESCRIPTION
MinGW does not export vtables when a method is exported