### PR TITLE
Track boost/http router consolidation

### DIFF
--- a/example/server/main.cpp
+++ b/example/server/main.cpp
@@ -20,7 +20,6 @@
 #include <boost/capy/read.hpp>
 #include <boost/corosio/signal_set.hpp>
 #include <boost/http/json/json_sink.hpp>
-#include <boost/http/server/flat_router.hpp>
 #include <boost/http/server/serve_static.hpp>
 #include <boost/http/request_parser.hpp>
 #include <boost/http/serializer.hpp>
@@ -128,7 +127,7 @@ void install_services()
 #endif
 }
 
-class application : public http::router
+class application : public http::router<http::route_params>
 {
     struct impl;
     impl* impl_;
@@ -136,7 +135,6 @@ class application : public http::router
 public:
     void listen(unsigned short)
     {
-        http::flat_router fr(std::move(*this));
     }
 };
 
@@ -188,7 +186,7 @@ int server_main( int argc, char* argv[] )
             co_return http::route_done;
         });
 #endif
-    http_server hs1(ioc, 40, http::flat_router(std::move(rr1)),
+    http_server hs1(ioc, 40, std::move(rr1),
         http::make_parser_config(http::parser_config(true)),
         http::make_serializer_config(http::serializer_config()));
     auto ec = hs1.bind(corosio::endpoint(ep, 80));
@@ -206,7 +204,7 @@ int server_main( int argc, char* argv[] )
     rr2.use( http::cors() );
     rr2.use( "/", http::serve_static( argv[2] ) );
     https_server hs2(ioc, std::atoi(argv[1]), tls,
-        http::flat_router(std::move(rr2)),
+        std::move(rr2),
         http::make_parser_config(http::parser_config(true)),
         http::make_serializer_config(http::serializer_config()));
     ec = hs2.bind(corosio::endpoint(ep, 443));

--- a/example/server/serve_log_admin.hpp
+++ b/example/server/serve_log_admin.hpp
@@ -16,7 +16,7 @@
 namespace boost {
 namespace beast2 {
 
-http::router
+http::router<http::route_params>
 serve_log_admin();
 
 } // beast2

--- a/include/boost/beast2/http_server.hpp
+++ b/include/boost/beast2/http_server.hpp
@@ -14,10 +14,10 @@
 #include <boost/corosio/tcp_server.hpp>
 #include <boost/corosio/io_context.hpp>
 #include <boost/http/config.hpp>
+#include <boost/http/server/router.hpp>
 #include <cstddef>
 
 namespace boost {
-namespace http { class flat_router; }
 namespace beast2 {
 
 /** An HTTP server for handling requests with coroutine-based I/O.
@@ -34,7 +34,7 @@ namespace beast2 {
     @par Example
     @code
     corosio::io_context ctx;
-    http::flat_router router;
+    http::router<http::route_params> router;
     router.add( http::verb::get, "/", my_handler );
 
     http_server srv(
@@ -73,7 +73,7 @@ public:
     http_server(
         corosio::io_context& ctx,
         std::size_t num_workers,
-        http::flat_router router,
+        http::router<http::route_params> router,
         http::shared_parser_config parser_cfg,
         http::shared_serializer_config serializer_cfg);
 };

--- a/include/boost/beast2/http_worker.hpp
+++ b/include/boost/beast2/http_worker.hpp
@@ -16,7 +16,6 @@
 #include <boost/http/config.hpp>
 #include <boost/http/request_parser.hpp>
 #include <boost/http/serializer.hpp>
-#include <boost/http/server/flat_router.hpp>
 #include <boost/http/server/router.hpp>
 
 namespace boost {
@@ -51,7 +50,7 @@ namespace beast2 {
 
         my_worker(
             corosio::io_context& ctx,
-            http::flat_router const& router,
+            http::router<http::route_params> const& router,
             http::shared_parser_config parser_cfg,
             http::shared_serializer_config serializer_cfg)
             : http_worker(router, parser_cfg, serializer_cfg)
@@ -81,7 +80,7 @@ namespace beast2 {
 class BOOST_BEAST2_DECL http_worker
 {
 public:
-    http::flat_router fr;
+    http::router<http::route_params> fr;
     http::route_params rp;
     capy::any_read_stream stream;
     http::request_parser parser;
@@ -95,7 +94,7 @@ public:
             serializer.
     */
     http_worker(
-        http::flat_router fr_,
+        http::router<http::route_params> fr_,
         http::shared_parser_config parser_cfg,
         http::shared_serializer_config serializer_cfg);
 

--- a/include/boost/beast2/https_server.hpp
+++ b/include/boost/beast2/https_server.hpp
@@ -15,10 +15,10 @@
 #include <boost/corosio/io_context.hpp>
 #include <boost/corosio/tls_context.hpp>
 #include <boost/http/config.hpp>
+#include <boost/http/server/router.hpp>
 #include <cstddef>
 
 namespace boost {
-namespace http { class flat_router; }
 namespace beast2 {
 
 /** An HTTPS server for handling requests with coroutine-based I/O.
@@ -42,7 +42,7 @@ namespace beast2 {
     tls_ctx.use_certificate_chain_file("server.crt", corosio::tls_file_format::pem);
     tls_ctx.use_private_key_file("server.key", corosio::tls_file_format::pem);
 
-    http::flat_router router;
+    http::router<http::route_params> router;
     router.add( http::verb::get, "/", my_handler );
 
     https_server srv(
@@ -86,7 +86,7 @@ public:
         corosio::io_context& ctx,
         std::size_t num_workers,
         corosio::tls_context tls_ctx,
-        http::flat_router router,
+        http::router<http::route_params> router,
         http::shared_parser_config parser_cfg,
         http::shared_serializer_config serializer_cfg);
 };

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/beast2/http_server.hpp>
 #include <boost/beast2/http_worker.hpp>
-#include <boost/http/server/flat_router.hpp>
 #include <boost/capy/task.hpp>
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/strand.hpp>
@@ -21,7 +20,6 @@
 #include <boost/http/server/router.hpp>
 #include <boost/http/serializer.hpp>
 #include <boost/http/string_body.hpp>
-#include <boost/http/server/basic_router.hpp>
 #include <boost/http/error.hpp>
 #include <boost/url/parse.hpp>
 #include <iostream>
@@ -31,11 +29,11 @@ namespace beast2 {
 
 struct http_server::impl
 {
-    http::flat_router router;
+    http::router<http::route_params> router;
     http::shared_parser_config parser_cfg;
     http::shared_serializer_config serializer_cfg;
 
-    impl(http::flat_router r)
+    impl(http::router<http::route_params> r)
         : router(std::move(r))
     {
     }
@@ -99,7 +97,7 @@ http_server::
 http_server(
     corosio::io_context& ctx,
     std::size_t num_workers,
-    http::flat_router router,
+    http::router<http::route_params> router,
     http::shared_parser_config parser_cfg,
     http::shared_serializer_config serializer_cfg)
     : tcp_server(ctx, ctx.get_executor())

--- a/src/http_worker.cpp
+++ b/src/http_worker.cpp
@@ -17,7 +17,7 @@ namespace beast2 {
 
 http_worker::
 http_worker(
-    http::flat_router fr_,
+    http::router<http::route_params> fr_,
     http::shared_parser_config parser_cfg,
     http::shared_serializer_config serializer_cfg)
     : fr(std::move(fr_))

--- a/src/https_server.cpp
+++ b/src/https_server.cpp
@@ -9,7 +9,6 @@
 
 #include <boost/beast2/https_server.hpp>
 #include <boost/beast2/http_worker.hpp>
-#include <boost/http/server/flat_router.hpp>
 #include <boost/capy/task.hpp>
 #include <boost/capy/cond.hpp>
 #include <boost/capy/ex/strand.hpp>
@@ -22,7 +21,6 @@
 #include <boost/http/server/router.hpp>
 #include <boost/http/serializer.hpp>
 #include <boost/http/string_body.hpp>
-#include <boost/http/server/basic_router.hpp>
 #include <boost/http/error.hpp>
 #include <boost/url/parse.hpp>
 #include <iostream>
@@ -34,13 +32,13 @@ namespace beast2 {
 struct https_server::impl
 {
     corosio::tls_context tls_ctx;
-    http::flat_router router;
+    http::router<http::route_params> router;
     http::shared_parser_config parser_cfg;
     http::shared_serializer_config serializer_cfg;
 
     impl(
         corosio::tls_context tc,
-        http::flat_router r)
+        http::router<http::route_params> r)
         : tls_ctx(std::move(tc))
         , router(std::move(r))
     {
@@ -132,7 +130,7 @@ https_server(
     corosio::io_context& ctx,
     std::size_t num_workers,
     corosio::tls_context tls_ctx,
-    http::flat_router router,
+    http::router<http::route_params> router,
     http::shared_parser_config parser_cfg,
     http::shared_serializer_config serializer_cfg)
     : tcp_server(ctx, ctx.get_executor())


### PR DESCRIPTION
boost/http removed the separate flat_router class and merged its flattened-dispatch behavior into router<P, HT>. Use http::router<http::route_params> directly in http_worker, http_server, https_server, and the example server.